### PR TITLE
Use normalized board target name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,10 @@ cmake_path(SET ZephyrBase $ENV{ZEPHYR_BASE})
 
 set(SMALLVM_PATH ../modules/microblocks/vm)
 set(ARDUINO_ZEPHYR_PATH ${ZephyrBase}/../modules/lib/Arduino-Zephyr-API)
-set(EXTRA_DTC_OVERLAY_FILE ${ARDUINO_ZEPHYR_PATH}/variants/${BOARD}/${BOARD}.overlay)
+
+# get value of NORMALIZED_BOARD_TARGET early
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS yaml boards)
+set(EXTRA_DTC_OVERLAY_FILE ${ARDUINO_ZEPHYR_PATH}/variants/${NORMALIZED_BOARD_TARGET}/${NORMALIZED_BOARD_TARGET}.overlay)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(blinky)


### PR DESCRIPTION
- The breakage seems to be caused by the following commit [0].

[0]: https://github.com/zephyrproject-rtos/gsoc-2022-arduino-core/commit/c85c47098a46b4a9d4e98017043baa955695c3b4